### PR TITLE
Refactor: Move all schema types to separate index.ts file

### DIFF
--- a/src/actions/favourite.ts
+++ b/src/actions/favourite.ts
@@ -1,8 +1,6 @@
 "use server";
-import {
-  watchListAndFavouriteSchema,
-  watchListAndFavouriteType,
-} from "@/schemas/movie.schema";
+import { watchListAndFavouriteSchema } from "@/schemas/movie.schema";
+import { watchListAndFavouriteType } from "@/types";
 import { cookies } from "next/headers";
 import { cookiesResponse } from "./watchlist";
 

--- a/src/actions/watchlist.ts
+++ b/src/actions/watchlist.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import {
-  watchListAndFavouriteSchema,
-  watchListAndFavouriteType,
-} from "@/schemas/movie.schema";
+import { watchListAndFavouriteSchema } from "@/schemas/movie.schema";
+import { watchListAndFavouriteType } from "@/types";
 import { cookies } from "next/headers";
 
 export type cookiesResponse = {

--- a/src/app/favourites/page.tsx
+++ b/src/app/favourites/page.tsx
@@ -1,27 +1,38 @@
 import { getAllFavouriteList } from "@/actions/favourite";
 import { cookiesResponse } from "@/actions/watchlist";
 import WatchlistCard from "@/components/ui/watchlist-card";
-import { watchListAndFavouriteType } from "@/schemas/movie.schema";
+import { watchListAndFavouriteType } from "@/types";
 
 const Page = async () => {
   const favourites = (await getAllFavouriteList()) as cookiesResponse & {
     data: watchListAndFavouriteType[];
   };
 
+  // Variable to hold the JSX for the watchlists content (handle empty watchlist).
+  let content;
+
+  if (favourites.data.length <= 0) {
+    content = (
+      <div className="mt-5 text-gray-400">
+        You haven&apos;t added any item shows to your favouriteList.
+      </div>
+    );
+  } else {
+    content = (
+      <div className="mt-5 space-y-4 ">
+        {favourites.data.map((watchlist: watchListAndFavouriteType) => (
+          <WatchlistCard data={watchlist} key={watchlist.id} as="watchlist" />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="container py-[30px]">
       <h1 className="text-[26px] font-semibold font-inter ">
         Favourites: {favourites.data.length}
       </h1>
-      <div className="mt-5 space-y-4 ">
-        {favourites.data.map((favourite: watchListAndFavouriteType) => (
-          <WatchlistCard
-            data={favourite}
-            key={favourite.id}
-            as="favouriteList"
-          />
-        ))}
-      </div>
+      {content}
     </div>
   );
 };

--- a/src/app/movies/[id]/_components/banner-action.tsx
+++ b/src/app/movies/[id]/_components/banner-action.tsx
@@ -15,10 +15,7 @@ import { toast } from "sonner";
 // Local imports
 import { addToFavouriteList } from "@/actions/favourite";
 import { addToWatchList, cookiesResponse } from "@/actions/watchlist";
-import {
-  movieDetailsSchemaType,
-  watchListAndFavouriteType,
-} from "@/schemas/movie.schema";
+import { movieDetailsSchemaType, watchListAndFavouriteType } from "@/types";
 
 interface Props {
   movie: movieDetailsSchemaType;

--- a/src/app/movies/[id]/_components/cast-crew-container.tsx
+++ b/src/app/movies/[id]/_components/cast-crew-container.tsx
@@ -6,10 +6,8 @@ import { useQuery } from "@tanstack/react-query";
 import CastCrewCard from "@/components/ui/cast-crew-card";
 import ResponseError from "@/components/ui/error";
 import SkeletonWrapper from "@/components/ui/skeleton-wrapper";
-import {
-  castAndCrewCombinedSchema,
-  castSchemaType,
-} from "@/schemas/movie.schema";
+import { castAndCrewCombinedSchema } from "@/schemas/movie.schema";
+import { castSchemaType } from "@/types";
 
 // Interface for the component props
 interface Props {

--- a/src/app/movies/[id]/_components/movie-details-banner.tsx
+++ b/src/app/movies/[id]/_components/movie-details-banner.tsx
@@ -3,7 +3,7 @@
 // Local imports
 import Poster from "@/components/ui/poster";
 import { fullImageSrc, getGenreNames } from "@/lib/utils";
-import { movieDetailsSchemaType } from "@/schemas/movie.schema";
+import { movieDetailsSchemaType } from "@/types";
 import BannerActions from "./banner-action";
 
 interface Props {

--- a/src/app/movies/[id]/_components/movie-details-container.tsx
+++ b/src/app/movies/[id]/_components/movie-details-container.tsx
@@ -1,8 +1,5 @@
 // Local imports
-import {
-  movieCardSchemaType,
-  movieDetailsSchemaType,
-} from "@/schemas/movie.schema";
+import { movieCardSchemaType, movieDetailsSchemaType } from "@/types";
 import CastCrewContainer from "./cast-crew-container";
 import MovieDetailsBanner from "./movie-details-banner";
 import MovieDetailsSidebar from "./movie-details-sidebar";

--- a/src/app/movies/[id]/_components/movie-details-sidebar.tsx
+++ b/src/app/movies/[id]/_components/movie-details-sidebar.tsx
@@ -2,8 +2,7 @@
 import { Link } from "lucide-react";
 
 // Local imports
-import { movieDetailsSchemaType } from "@/schemas/movie.schema";
-import { genre } from "@/types";
+import { genre, movieDetailsSchemaType } from "@/types";
 
 interface Props {
   movie: movieDetailsSchemaType;

--- a/src/app/movies/[id]/_components/movie-recomendation-container.tsx
+++ b/src/app/movies/[id]/_components/movie-recomendation-container.tsx
@@ -1,5 +1,5 @@
 import MovieRecomendationCard from "@/components/ui/movie-recomendation-card";
-import { movieCardSchemaType } from "@/schemas/movie.schema";
+import { movieCardSchemaType } from "@/types";
 
 interface Props {
   recomendations?: movieCardSchemaType[];

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -1,11 +1,11 @@
 // Next.js will invalidate the cache when a
 
+import { movieDetailsSchema } from "@/schemas/movie.schema";
 import {
   movieCardSchemaType,
-  movieDetailsSchema,
   movieDetailsSchemaType,
   populerMoviesResponseSchemaType,
-} from "@/schemas/movie.schema";
+} from "@/types";
 import MovieDetailsContainer from "./_components/movie-details-container";
 
 // request comes in, at most once every 60 seconds.

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -1,22 +1,37 @@
 import { cookiesResponse, getAllWatchList } from "@/actions/watchlist";
 import WatchlistCard from "@/components/ui/watchlist-card";
-import { watchListAndFavouriteType } from "@/schemas/movie.schema";
+import { watchListAndFavouriteType } from "@/types";
 
 const Page = async () => {
   const watchlists = (await getAllWatchList()) as cookiesResponse & {
     data: watchListAndFavouriteType[];
   };
 
-  return (
-    <div className="container py-[30px]">
-      <h1 className="text-[26px] font-semibold font-inter ">
-        My Watchlist: {watchlists.data.length}
-      </h1>
+  // Variable to hold the JSX for the watchlists content (handle empty watchlist).
+  let content;
+
+  if (watchlists.data.length <= 0) {
+    content = (
+      <div className="mt-5 text-gray-400">
+        You haven&&apos;t added any item shows to your watchlist.
+      </div>
+    );
+  } else {
+    content = (
       <div className="mt-5 space-y-4 ">
         {watchlists.data.map((watchlist: watchListAndFavouriteType) => (
           <WatchlistCard data={watchlist} key={watchlist.id} as="watchlist" />
         ))}
       </div>
+    );
+  }
+
+  return (
+    <div className="container py-[30px]">
+      <h1 className="text-[26px] font-semibold font-inter ">
+        My Watchlist: {watchlists.data.length}
+      </h1>
+      {content}
     </div>
   );
 };

--- a/src/components/sections/populer-movies.tsx
+++ b/src/components/sections/populer-movies.tsx
@@ -4,11 +4,8 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 
 // Local imports
-import {
-  movieCardSchemaType,
-  populerMoviesResponseSchema,
-  populerMoviesResponseSchemaType,
-} from "@/schemas/movie.schema";
+import { populerMoviesResponseSchema } from "@/schemas/movie.schema";
+import { movieCardSchemaType, populerMoviesResponseSchemaType } from "@/types";
 import ResponseError from "../ui/error";
 import MovieCard from "../ui/movie-card";
 import SkeletonWrapper from "../ui/skeleton-wrapper";

--- a/src/components/ui/cast-crew-card.tsx
+++ b/src/components/ui/cast-crew-card.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 // Local imports
 import { blurDataUrl } from "@/lib/blurDataUrl";
 import { fullImageSrc } from "@/lib/utils";
-import { castSchemaType } from "@/schemas/movie.schema";
+import { castSchemaType } from "@/types";
 
 interface castProps {
   data: castSchemaType;

--- a/src/components/ui/movie-card.tsx
+++ b/src/components/ui/movie-card.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 
 // Local imports
-import { movieCardSchemaType } from "@/schemas/movie.schema";
+import { movieCardSchemaType } from "@/types";
 import Poster from "./poster";
 
 const MovieCard = ({ movie }: { movie: movieCardSchemaType }) => {

--- a/src/components/ui/movie-recomendation-card.tsx
+++ b/src/components/ui/movie-recomendation-card.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { blurDataUrl } from "@/lib/blurDataUrl";
 import { fullImageSrc } from "@/lib/utils";
-import { movieCardSchemaType } from "@/schemas/movie.schema";
+import { movieCardSchemaType } from "@/types";
 
 interface Props {
   data: movieCardSchemaType;

--- a/src/components/ui/watchlist-card.tsx
+++ b/src/components/ui/watchlist-card.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 import { addToFavouriteList } from "@/actions/favourite";
 import { addToWatchList } from "@/actions/watchlist";
 import { fullImageSrc } from "@/lib/utils";
-import { watchListAndFavouriteType } from "@/schemas/movie.schema";
+import { watchListAndFavouriteType } from "@/types";
 
 interface Props {
   data: watchListAndFavouriteType;

--- a/src/schemas/movie.schema.ts
+++ b/src/schemas/movie.schema.ts
@@ -2,149 +2,416 @@ import { z } from "zod";
 
 // Schema defination for movie card
 export const movieCardSchema = z.object({
-  adult: z.boolean(),
-  backdrop_path: z.string().nullable(),
-  genre_ids: z.array(z.number()),
-  id: z.number(),
-  original_language: z.string(),
-  original_title: z.string(),
-  overview: z.string(),
-  popularity: z.number(),
-  poster_path: z.string().nullable(),
-  release_date: z.string(),
-  title: z.string(),
-  video: z.boolean(),
-  vote_average: z.number(),
-  vote_count: z.number(),
+  adult: z.boolean({
+    required_error: "The 'adult' field is required.",
+    invalid_type_error: "The 'adult' field must be a boolean value.",
+  }),
+  backdrop_path: z
+    .string({
+      invalid_type_error: "The 'backdrop_path' field must be a string.",
+    })
+    .nullable(),
+  genre_ids: z.array(z.number(), {
+    required_error: "The 'genre_ids' field is required.",
+    invalid_type_error: "The 'genre_ids' field must be an array of numbers.",
+  }),
+  id: z.number({
+    required_error: "The 'id' field is required.",
+    invalid_type_error: "The 'id' field must be a number.",
+  }),
+  original_language: z.string({
+    required_error: "The 'original_language' field is required.",
+    invalid_type_error: "The 'original_language' field must be a string.",
+  }),
+  original_title: z.string({
+    required_error: "The 'original_title' field is required.",
+    invalid_type_error: "The 'original_title' field must be a string.",
+  }),
+  overview: z.string({
+    required_error: "The 'overview' field is required.",
+    invalid_type_error: "The 'overview' field must be a string.",
+  }),
+  popularity: z.number({
+    required_error: "The 'popularity' field is required.",
+    invalid_type_error: "The 'popularity' field must be a number.",
+  }),
+  poster_path: z
+    .string({
+      invalid_type_error: "The 'poster_path' field must be a string.",
+    })
+    .nullable(),
+  release_date: z.string({
+    required_error: "The 'release_date' field is required.",
+    invalid_type_error: "The 'release_date' field must be a string.",
+  }),
+  title: z.string({
+    required_error: "The 'title' field is required.",
+    invalid_type_error: "The 'title' field must be a string.",
+  }),
+  video: z.boolean({
+    required_error: "The 'video' field is required.",
+    invalid_type_error: "The 'video' field must be a boolean value.",
+  }),
+  vote_average: z.number({
+    required_error: "The 'vote_average' field is required.",
+    invalid_type_error: "The 'vote_average' field must be a number.",
+  }),
+  vote_count: z.number({
+    required_error: "The 'vote_count' field is required.",
+    invalid_type_error: "The 'vote_count' field must be a number.",
+  }),
 });
-
-export type movieCardSchemaType = z.infer<typeof movieCardSchema>;
 
 // Schema defination for populer movies api response
 export const populerMoviesResponseSchema = z.object({
-  page: z.number(),
-  results: z.array(movieCardSchema),
-  total_pages: z.number(),
-  total_results: z.number(),
+  page: z.number({
+    required_error: "The 'page' field is required.",
+    invalid_type_error:
+      "The 'page' field must be a number representing the current page of results.",
+  }),
+  results: z.array(movieCardSchema, {
+    required_error: "The 'results' field is required.",
+    invalid_type_error:
+      "The 'results' field must be an array of movie objects.",
+  }),
+  total_pages: z.number({
+    required_error: "The 'total_pages' field is required.",
+    invalid_type_error:
+      "The 'total_pages' field must be a number representing the total number of pages available.",
+  }),
+  total_results: z.number({
+    required_error: "The 'total_results' field is required.",
+    invalid_type_error:
+      "The 'total_results' field must be a number representing the total number of results available.",
+  }),
 });
-
-export type populerMoviesResponseSchemaType = z.infer<
-  typeof populerMoviesResponseSchema
->;
 
 // Schema defination for movie details
 export const movieDetailsSchema = z.object({
-  adult: z.boolean(),
-  backdrop_path: z.string().nullable(),
-  belongs_to_collection: z.any().nullable(),
-  budget: z.number(),
+  adult: z.boolean({
+    required_error: "The 'adult' field is required.",
+    invalid_type_error: "The 'adult' field must be a boolean value.",
+  }),
+  backdrop_path: z
+    .string({
+      invalid_type_error: "The 'backdrop_path' field must be a string.",
+    })
+    .nullable(),
+  belongs_to_collection: z.any().nullable().or(z.null()).optional(),
+  budget: z.number({
+    required_error: "The 'budget' field is required.",
+    invalid_type_error:
+      "The 'budget' field must be a number representing the movie's budget.",
+  }),
   genres: z.array(
     z.object({
-      id: z.number(),
-      name: z.string(),
-    })
+      id: z.number({
+        required_error: "Each genre must include an 'id' field.",
+        invalid_type_error: "The 'id' field in genres must be a number.",
+      }),
+      name: z.string({
+        required_error: "Each genre must include a 'name' field.",
+        invalid_type_error: "The 'name' field in genres must be a string.",
+      }),
+    }),
+    {
+      required_error: "The 'genres' field is required.",
+      invalid_type_error:
+        "The 'genres' field must be an array of genre objects.",
+    }
   ),
-  homepage: z.string().nullable(),
-  id: z.number(),
-  imdb_id: z.string().nullable(),
-  origin_country: z.array(z.string()),
-  original_language: z.string(),
-  original_title: z.string(),
-  overview: z.string(),
-  popularity: z.number(),
-  poster_path: z.string().nullable(),
+  homepage: z
+    .string({
+      invalid_type_error: "The 'homepage' field must be a string.",
+    })
+    .nullable(),
+  id: z.number({
+    required_error: "The 'id' field is required.",
+    invalid_type_error: "The 'id' field must be a number.",
+  }),
+  imdb_id: z
+    .string({
+      invalid_type_error: "The 'imdb_id' field must be a string.",
+    })
+    .nullable(),
+  origin_country: z.array(z.string(), {
+    required_error: "The 'origin_country' field is required.",
+    invalid_type_error:
+      "The 'origin_country' field must be an array of strings.",
+  }),
+  original_language: z.string({
+    required_error: "The 'original_language' field is required.",
+    invalid_type_error: "The 'original_language' field must be a string.",
+  }),
+  original_title: z.string({
+    required_error: "The 'original_title' field is required.",
+    invalid_type_error: "The 'original_title' field must be a string.",
+  }),
+  overview: z.string({
+    required_error: "The 'overview' field is required.",
+    invalid_type_error: "The 'overview' field must be a string.",
+  }),
+  popularity: z.number({
+    required_error: "The 'popularity' field is required.",
+    invalid_type_error: "The 'popularity' field must be a number.",
+  }),
+  poster_path: z
+    .string({
+      invalid_type_error: "The 'poster_path' field must be a string.",
+    })
+    .nullable(),
   production_companies: z.array(
     z.object({
-      id: z.number(),
-      logo_path: z.string().nullable(),
-      name: z.string(),
-      origin_country: z.string(),
-    })
+      id: z.number({
+        required_error: "Each production company must include an 'id' field.",
+        invalid_type_error:
+          "The 'id' field in production companies must be a number.",
+      }),
+      logo_path: z
+        .string({
+          invalid_type_error:
+            "The 'logo_path' field in production companies must be a string.",
+        })
+        .nullable(),
+      name: z.string({
+        required_error: "Each production company must include a 'name' field.",
+        invalid_type_error:
+          "The 'name' field in production companies must be a string.",
+      }),
+      origin_country: z.string({
+        required_error:
+          "Each production company must include an 'origin_country' field.",
+        invalid_type_error:
+          "The 'origin_country' field in production companies must be a string.",
+      }),
+    }),
+    {
+      required_error: "The 'production_companies' field is required.",
+      invalid_type_error:
+        "The 'production_companies' field must be an array of production company objects.",
+    }
   ),
   production_countries: z.array(
     z.object({
-      iso_3166_1: z.string(),
-      name: z.string(),
-    })
+      iso_3166_1: z.string({
+        required_error:
+          "Each production country must include an 'iso_3166_1' field.",
+        invalid_type_error:
+          "The 'iso_3166_1' field in production countries must be a string.",
+      }),
+      name: z.string({
+        required_error: "Each production country must include a 'name' field.",
+        invalid_type_error:
+          "The 'name' field in production countries must be a string.",
+      }),
+    }),
+    {
+      required_error: "The 'production_countries' field is required.",
+      invalid_type_error:
+        "The 'production_countries' field must be an array of production country objects.",
+    }
   ),
-  release_date: z.string().nullable(),
-  revenue: z.number(),
-  runtime: z.number().nullable(),
+  release_date: z
+    .string({
+      invalid_type_error: "The 'release_date' field must be a string.",
+    })
+    .nullable(),
+  revenue: z.number({
+    required_error: "The 'revenue' field is required.",
+    invalid_type_error: "The 'revenue' field must be a number.",
+  }),
+  runtime: z
+    .number({
+      invalid_type_error: "The 'runtime' field must be a number.",
+    })
+    .nullable(),
   spoken_languages: z.array(
     z.object({
-      english_name: z.string(),
-      iso_639_1: z.string(),
-      name: z.string(),
-    })
+      english_name: z.string({
+        required_error:
+          "Each spoken language must include an 'english_name' field.",
+        invalid_type_error:
+          "The 'english_name' field in spoken languages must be a string.",
+      }),
+      iso_639_1: z.string({
+        required_error:
+          "Each spoken language must include an 'iso_639_1' field.",
+        invalid_type_error:
+          "The 'iso_639_1' field in spoken languages must be a string.",
+      }),
+      name: z.string({
+        required_error: "Each spoken language must include a 'name' field.",
+        invalid_type_error:
+          "The 'name' field in spoken languages must be a string.",
+      }),
+    }),
+    {
+      required_error: "The 'spoken_languages' field is required.",
+      invalid_type_error:
+        "The 'spoken_languages' field must be an array of spoken language objects.",
+    }
   ),
-  status: z.string(),
-  tagline: z.string().nullable(),
-  title: z.string(),
-  video: z.boolean(),
-  vote_average: z.number(),
-  vote_count: z.number(),
+  status: z.string({
+    required_error: "The 'status' field is required.",
+    invalid_type_error: "The 'status' field must be a string.",
+  }),
+  tagline: z
+    .string({
+      invalid_type_error: "The 'tagline' field must be a string.",
+    })
+    .nullable(),
+  title: z.string({
+    required_error: "The 'title' field is required.",
+    invalid_type_error: "The 'title' field must be a string.",
+  }),
+  video: z.boolean({
+    required_error: "The 'video' field is required.",
+    invalid_type_error: "The 'video' field must be a boolean value.",
+  }),
+  vote_average: z.number({
+    required_error: "The 'vote_average' field is required.",
+    invalid_type_error: "The 'vote_average' field must be a number.",
+  }),
+  vote_count: z.number({
+    required_error: "The 'vote_count' field is required.",
+    invalid_type_error: "The 'vote_count' field must be a number.",
+  }),
 });
-
-export type movieDetailsSchemaType = z.infer<typeof movieDetailsSchema>;
 
 // Cast
 export const castSchema = z.object({
-  adult: z.boolean(),
-  gender: z.number().int().min(0),
-  id: z.number().int(),
-  known_for_department: z.string(),
-  name: z.string(),
-  original_name: z.string(),
-  popularity: z.number(),
-  profile_path: z.string().nullable(),
-  cast_id: z.number().int(),
-  character: z.string(),
-  credit_id: z.string(),
-  order: z.number().int(),
+  adult: z.boolean({
+    required_error: "The 'adult' field is required.",
+    invalid_type_error: "The 'adult' field must be a boolean value.",
+  }),
+  gender: z.number().int().min(0, {
+    message: "The 'gender' field is required.",
+  }),
+  id: z.number().int({
+    message: "The 'id' field is required.",
+  }),
+  known_for_department: z.string({
+    required_error: "The 'known_for_department' field is required.",
+    invalid_type_error:
+      "The 'known_for_department' field must be a string indicating the department.",
+  }),
+  name: z.string({
+    required_error: "The 'name' field is required.",
+    invalid_type_error: "The 'name' field must be a string.",
+  }),
+  original_name: z.string({
+    required_error: "The 'original_name' field is required.",
+    invalid_type_error: "The 'original_name' field must be a string.",
+  }),
+  popularity: z.number({
+    required_error: "The 'popularity' field is required.",
+    invalid_type_error: "The 'popularity' field must be a number.",
+  }),
+  profile_path: z
+    .string({
+      invalid_type_error: "The 'profile_path' field must be a string.",
+    })
+    .nullable(),
+  cast_id: z.number().int({
+    message: "The 'cast_id' field is required.",
+  }),
+  character: z.string({
+    required_error: "The 'character' field is required.",
+    invalid_type_error:
+      "The 'character' field must be a string indicating the character name.",
+  }),
+  credit_id: z.string({
+    required_error: "The 'credit_id' field is required.",
+    invalid_type_error:
+      "The 'credit_id' field must be a string representing the credit ID.",
+  }),
+  order: z.number().int({
+    message: "The 'order' field is required.",
+  }),
 });
-
-export type castSchemaType = z.infer<typeof castSchema>;
 
 export const crewSchema = z.object({
-  adult: z.boolean(),
-  gender: z.number().int().min(0),
-  id: z.number().int(),
-  known_for_department: z.string(),
-  name: z.string(),
-  original_name: z.string(),
-  popularity: z.number(),
-  profile_path: z.string().nullable(),
-  credit_id: z.string(),
-  department: z.string(),
-  job: z.string(),
+  adult: z.boolean({
+    required_error: "The 'adult' field is required.",
+    invalid_type_error: "The 'adult' field must be a boolean value.",
+  }),
+  gender: z.number().int().min(0, {
+    message: "The 'gender' field is required.",
+  }),
+  id: z.number().int({
+    message: "The 'id' field is required.",
+  }),
+  known_for_department: z.string({
+    required_error: "The 'known_for_department' field is required.",
+    invalid_type_error:
+      "The 'known_for_department' field must be a string representing the department.",
+  }),
+  name: z.string({
+    required_error: "The 'name' field is required.",
+    invalid_type_error: "The 'name' field must be a string.",
+  }),
+  original_name: z.string({
+    required_error: "The 'original_name' field is required.",
+    invalid_type_error: "The 'original_name' field must be a string.",
+  }),
+  popularity: z.number({
+    required_error: "The 'popularity' field is required.",
+    invalid_type_error: "The 'popularity' field must be a number.",
+  }),
+  profile_path: z
+    .string({
+      invalid_type_error: "The 'profile_path' field must be a string.",
+    })
+    .nullable(),
+  credit_id: z.string({
+    required_error: "The 'credit_id' field is required.",
+    invalid_type_error:
+      "The 'credit_id' field must be a string representing the credit ID.",
+  }),
+  department: z.string({
+    required_error: "The 'department' field is required.",
+    invalid_type_error:
+      "The 'department' field must be a string representing the department.",
+  }),
+  job: z.string({
+    required_error: "The 'job' field is required.",
+    invalid_type_error:
+      "The 'job' field must be a string representing the job title.",
+  }),
 });
-
-export type crewSchemaType = z.infer<typeof crewSchema>;
 
 // Combine cast and crew schemas into a new schema
 export const castAndCrewCombinedSchema = z.object({
-  cast: z.array(castSchema),
-  crew: z.array(crewSchema),
+  cast: z.array(castSchema, {
+    required_error: "The 'cast' field is required.",
+    invalid_type_error: "The 'cast' field must be an array of cast objects.",
+  }),
+  crew: z.array(crewSchema, {
+    required_error: "The 'crew' field is required.",
+    invalid_type_error: "The 'crew' field must be an array of crew objects.",
+  }),
 });
-
-export type castAndCrewResponseType = {
-  cast: castSchemaType[];
-  crew: crewSchemaType[];
-  id: number;
-};
 
 export const watchListAndFavouriteSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  banner_path: z.string().nullable(),
-  release_date: z.string().nullable(),
-  overview: z.string(),
+  id: z.number({
+    message: "The 'id' field is required.",
+  }),
+  title: z.string({
+    required_error: "The 'title' field is required.",
+    invalid_type_error: "The 'title' field must be a string.",
+  }),
+  banner_path: z
+    .string({
+      invalid_type_error: "The 'banner_path' field must be a string.",
+    })
+    .nullable(),
+  release_date: z
+    .string({
+      invalid_type_error: "The 'release_date' field must be a string.",
+    })
+    .nullable(),
+  overview: z.string({
+    required_error: "The 'overview' field is required.",
+    invalid_type_error: "The 'overview' field must be a string.",
+  }),
 });
-
-export type watchListAndFavouriteType = {
-  id: number;
-  title: string;
-  banner_path: string | null;
-  release_date: string | null;
-  overview: string;
-};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,58 @@
+// Import schemas from the movie.schema file. These schemas are used to validate and type-check
+// the structure of various movie-related objects like cast, crew, movie card, movie details,
+// and popular movies responses.
+import {
+  castSchema,
+  crewSchema,
+  movieCardSchema,
+  movieDetailsSchema,
+  populerMoviesResponseSchema,
+} from "@/schemas/movie.schema";
+import { z } from "zod";
+
+// Define a genre type with id and name properties, representing movie genre data.
 export type genre = {
   id: number;
   name: string;
+};
+
+// Define a type for movieCardSchema, inferred from the movieCardSchema schema.
+// This is used for data structures related to individual movie cards.
+export type movieCardSchemaType = z.infer<typeof movieCardSchema>;
+
+// Define a type for popularMoviesResponseSchema, inferred from the
+// populerMoviesResponseSchema schema. This is used for data structures that
+// handle responses containing popular movies.
+export type populerMoviesResponseSchemaType = z.infer<
+  typeof populerMoviesResponseSchema
+>;
+
+// Define a type for movieDetailsSchema, inferred from the movieDetailsSchema schema.
+// This is used for detailed movie data.
+export type movieDetailsSchemaType = z.infer<typeof movieDetailsSchema>;
+
+// Define a type for castSchema, inferred from the castSchema schema.
+// This type is used for individual cast member data.
+export type castSchemaType = z.infer<typeof castSchema>;
+
+// Define a type for crewSchema, inferred from the crewSchema schema.
+// This type is used for individual crew member data.
+export type crewSchemaType = z.infer<typeof crewSchema>;
+
+// Define a type for a response that includes both cast and crew data.
+// This type contains an array of cast and crew objects and an id property.
+export type castAndCrewResponseType = {
+  cast: castSchemaType[];
+  crew: crewSchemaType[];
+  id: number;
+};
+
+// Define a type for items in a user's watchlist or favorites list.
+// This type includes properties for id, title, banner image, release date, and overview.
+export type watchListAndFavouriteType = {
+  id: number;
+  title: string;
+  banner_path: string | null;
+  release_date: string | null;
+  overview: string;
 };


### PR DESCRIPTION
- Refactored the schema definitions by moving all type definitions related to movie schemas to a new 	ypes/index.ts file.
- This change improves code organization and maintainability by centralizing type definitions in a dedicated location.
- Added handling for empty watchlists and favorite lists to ensure better user experience and prevent errors when lists are empty.